### PR TITLE
Fix structure plot range issue with normalize option and ylim

### DIFF
--- a/docs/articles/get-started.md
+++ b/docs/articles/get-started.md
@@ -131,6 +131,7 @@ document-topic distributions.
 ``` python
 plot_structure(
     true_L_sorted,
+    normalize_rows=True,
     title="True document-topic distributions (sorted)",
     output_file="L-true.png",
 )
@@ -141,6 +142,7 @@ plot_structure(
 ``` python
 plot_structure(
     learned_L_sorted,
+    normalize_rows=True,
     title="Learned document-topic distributions (sorted and aligned)",
     output_file="L-learned.png",
 )

--- a/docs/articles/get-started.qmd
+++ b/docs/articles/get-started.qmd
@@ -129,6 +129,7 @@ We can use a "Structure plot" to visualize and compare the document-topic distri
 ```{python}
 plot_structure(
     true_L_sorted,
+    normalize_rows=True,
     title="True document-topic distributions (sorted)",
     output_file="L-true.png",
 )
@@ -139,6 +140,7 @@ plot_structure(
 ```{python}
 plot_structure(
     learned_L_sorted,
+    normalize_rows=True,
     title="Learned document-topic distributions (sorted and aligned)",
     output_file="L-learned.png",
 )

--- a/examples/get-started.py
+++ b/examples/get-started.py
@@ -36,6 +36,7 @@ learned_L_sorted = learned_L_aligned[sorted_indices]
 
 plot_structure(
     true_L_sorted,
+    normalize_rows=True,
     title="True document-topic distributions (sorted)",
     output_file="L-true.png",
 )
@@ -43,6 +44,7 @@ plot_structure(
 
 plot_structure(
     learned_L_sorted,
+    normalize_rows=True,
     title="Learned document-topic distributions (sorted and aligned)",
     output_file="L-learned.png",
 )

--- a/src/tinytopics/plot.py
+++ b/src/tinytopics/plot.py
@@ -27,6 +27,7 @@ def plot_loss(losses, figsize=(10, 8), dpi=300, title="Loss curve", output_file=
 
 def plot_structure(
     L_matrix,
+    normalize_rows=False,
     figsize=(12, 6),
     dpi=300,
     title="Structure Plot",
@@ -38,12 +39,16 @@ def plot_structure(
 
     Args:
         L_matrix (np.ndarray): Document-topic distribution matrix.
+        normalize_rows (bool, optional): If True, normalizes each row of L_matrix to sum to 1.
         figsize (tuple, optional): Plot size. Default is (12, 6).
         dpi (int, optional): Plot resolution. Default is 300.
         title (str): Plot title.
         color_palette (list or matplotlib colormap, optional): Custom color palette.
         output_file (str, optional): File path to save the plot. If None, displays the plot.
     """
+    if normalize_rows:
+        L_matrix = L_matrix / L_matrix.sum(axis=1, keepdims=True)
+
     n_documents, n_topics = L_matrix.shape
     ind = np.arange(n_documents)  # Document indices
     cumulative = np.zeros(n_documents)
@@ -71,6 +76,7 @@ def plot_structure(
     plt.xlabel("Documents (sorted)")
     plt.ylabel("Topic Proportions")
     plt.xlim([0, n_documents])
+    plt.ylim(0, 1)
     plt.tight_layout()
 
     if output_file:


### PR DESCRIPTION
This PR fixes the structure plot range issue (white space above the 1.0 line of the stacked bar chart) by:

- Adding a `normalize_rows` option to `plot_structure()` to normalize rows so that they all sum exactly to 1.
- Explicitly setting the y-axis limit to [0, 1].