### PR TITLE
Typing

### DIFF
--- a/src/tinytopics/colors.py
+++ b/src/tinytopics/colors.py
@@ -1,4 +1,5 @@
-from typing import List, Union, Literal, overload
+from typing import Union, Literal, overload
+from collections.abc import Sequence, MutableSequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -12,7 +13,7 @@ ColorFormat = Literal["hex", "rgb", "lab"]
 
 
 @overload
-def pal_tinytopics(format: Literal["hex"]) -> List[str]: ...
+def pal_tinytopics(format: Literal["hex"]) -> MutableSequence[str]: ...
 
 
 @overload
@@ -21,7 +22,7 @@ def pal_tinytopics(format: Literal["rgb", "lab"]) -> NDArray[np.float64]: ...
 
 def pal_tinytopics(
     format: ColorFormat = "hex",
-) -> Union[List[str], NDArray[np.float64]]:
+) -> Union[MutableSequence[str], NDArray[np.float64]]:
     """
     The tinytopics 10 color palette.
 
@@ -45,7 +46,7 @@ def pal_tinytopics(
     Raises:
         ValueError: If format is not 'hex', 'rgb', or 'lab'.
     """
-    TINYTOPICS_10_COLORS: tuple[str, ...] = (
+    TINYTOPICS_10_COLORS: Sequence[str] = (
         "#4269D0",  # Blue
         "#EFB118",  # Orange
         "#3CA951",  # Green

--- a/src/tinytopics/colors.py
+++ b/src/tinytopics/colors.py
@@ -1,4 +1,4 @@
-from typing import Union, Literal, overload
+from typing import Literal, overload
 from collections.abc import Sequence, MutableSequence
 
 import numpy as np
@@ -22,7 +22,7 @@ def pal_tinytopics(format: Literal["rgb", "lab"]) -> NDArray[np.float64]: ...
 
 def pal_tinytopics(
     format: ColorFormat = "hex",
-) -> Union[MutableSequence[str], NDArray[np.float64]]:
+) -> MutableSequence[str] | NDArray[np.float64]:
     """
     The tinytopics 10 color palette.
 

--- a/src/tinytopics/fit.py
+++ b/src/tinytopics/fit.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Tuple
 from collections.abc import Sequence
 
 import torch
@@ -37,7 +37,7 @@ def fit_model(
     T_0: int = 20,
     T_mult: int = 1,
     weight_decay: float = 1e-5,
-    device: Optional[torch.device] = None,
+    device: torch.device | None = None,
 ) -> Tuple[NeuralPoissonNMF, Sequence[float]]:
     """
     Fit topic model using sum-to-one constrained neural Poisson NMF,

--- a/src/tinytopics/fit.py
+++ b/src/tinytopics/fit.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor
@@ -37,7 +38,7 @@ def fit_model(
     T_mult: int = 1,
     weight_decay: float = 1e-5,
     device: Optional[torch.device] = None,
-) -> Tuple[NeuralPoissonNMF, List[float]]:
+) -> Tuple[NeuralPoissonNMF, Sequence[float]]:
     """
     Fit topic model using sum-to-one constrained neural Poisson NMF,
     optimized with AdamW and a cosine annealing with warm restarts scheduler.
@@ -69,7 +70,7 @@ def fit_model(
         optimizer, T_0=T_0, T_mult=T_mult, eta_min=base_lr
     )
 
-    losses: List[float] = []
+    losses: Sequence[float] = []
     num_batches: int = n // batch_size
 
     with tqdm(total=num_epochs, desc="Training Progress") as pbar:

--- a/src/tinytopics/models.py
+++ b/src/tinytopics/models.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -7,7 +5,7 @@ from torch import Tensor
 
 class NeuralPoissonNMF(nn.Module):
     def __init__(
-        self, n: int, m: int, k: int, device: Optional[torch.device] = None
+        self, n: int, m: int, k: int, device: torch.device | None = None
     ) -> None:
         """
         Neural Poisson NMF model with sum-to-one constraints on document-topic and topic-term distributions.

--- a/src/tinytopics/plot.py
+++ b/src/tinytopics/plot.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
+from collections.abc import Sequence
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -9,11 +10,11 @@ from .colors import scale_color_tinytopics
 
 
 def plot_loss(
-    losses: List[float],
+    losses: Sequence[float],
     figsize: Tuple[int, int] = (10, 8),
     dpi: int = 300,
     title: str = "Loss curve",
-    color_palette: Optional[Union[List[str], str]] = None,
+    color_palette: Optional[Union[Sequence[str], str]] = None,
     output_file: Optional[str] = None,
 ) -> None:
     """
@@ -48,7 +49,7 @@ def plot_structure(
     figsize: Tuple[int, int] = (12, 6),
     dpi: int = 300,
     title: str = "Structure Plot",
-    color_palette: Optional[Union[List[str], str]] = None,
+    color_palette: Optional[Union[Sequence[str], str]] = None,
     output_file: Optional[str] = None,
 ) -> None:
     """
@@ -101,11 +102,11 @@ def plot_structure(
 def plot_top_terms(
     F_matrix: np.ndarray,
     n_top_terms: int = 10,
-    term_names: Optional[List[str]] = None,
+    term_names: Optional[Sequence[str]] = None,
     figsize: Tuple[int, int] = (10, 8),
     dpi: int = 300,
     title: str = "Top Terms",
-    color_palette: Optional[Union[List[str], str]] = None,
+    color_palette: Optional[Union[Sequence[str], str]] = None,
     nrows: Optional[int] = None,
     ncols: Optional[int] = None,
     output_file: Optional[str] = None,

--- a/src/tinytopics/plot.py
+++ b/src/tinytopics/plot.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Tuple
 from collections.abc import Sequence
 
 import numpy as np
@@ -14,8 +14,8 @@ def plot_loss(
     figsize: Tuple[int, int] = (10, 8),
     dpi: int = 300,
     title: str = "Loss curve",
-    color_palette: Optional[Union[Sequence[str], str]] = None,
-    output_file: Optional[str] = None,
+    color_palette: Sequence[str] | str | None = None,
+    output_file: str | None = None,
 ) -> None:
     """
     Plot the loss curve over training epochs.
@@ -49,8 +49,8 @@ def plot_structure(
     figsize: Tuple[int, int] = (12, 6),
     dpi: int = 300,
     title: str = "Structure Plot",
-    color_palette: Optional[Union[Sequence[str], str]] = None,
-    output_file: Optional[str] = None,
+    color_palette: Sequence[str] | str | None = None,
+    output_file: str | None = None,
 ) -> None:
     """
     Structure plot for visualizing document-topic distributions.
@@ -102,14 +102,14 @@ def plot_structure(
 def plot_top_terms(
     F_matrix: np.ndarray,
     n_top_terms: int = 10,
-    term_names: Optional[Sequence[str]] = None,
+    term_names: Sequence[str] | None = None,
     figsize: Tuple[int, int] = (10, 8),
     dpi: int = 300,
     title: str = "Top Terms",
-    color_palette: Optional[Union[Sequence[str], str]] = None,
-    nrows: Optional[int] = None,
-    ncols: Optional[int] = None,
-    output_file: Optional[str] = None,
+    color_palette: Sequence[str] | str | None = None,
+    nrows: int | None = None,
+    ncols: int | None = None,
+    output_file: str | None = None,
 ) -> None:
     """
     Plot top terms for each topic in horizontal bar charts.

--- a/src/tinytopics/utils.py
+++ b/src/tinytopics/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Tuple
 from collections.abc import Sequence, MutableMapping
 from collections import defaultdict
 
@@ -26,7 +26,7 @@ def generate_synthetic_data(
     m: int,
     k: int,
     avg_doc_length: int = 1000,
-    device: Optional[torch.device] = None,
+    device: torch.device | None = None,
 ) -> Tuple[torch.Tensor, np.ndarray, np.ndarray]:
     """
     Generate synthetic document-term matrix for testing the model.

--- a/src/tinytopics/utils.py
+++ b/src/tinytopics/utils.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple
+from collections.abc import Sequence, MutableMapping
 from collections import defaultdict
 
 import torch
@@ -103,7 +104,7 @@ def align_topics(true_F: np.ndarray, learned_F: np.ndarray) -> np.ndarray:
     return col_ind
 
 
-def sort_documents(L_matrix: np.ndarray) -> List[int]:
+def sort_documents(L_matrix: np.ndarray) -> Sequence[int]:
     """
     Sort documents grouped by dominant topics for visualization.
 
@@ -111,23 +112,25 @@ def sort_documents(L_matrix: np.ndarray) -> List[int]:
         L_matrix (np.ndarray): Document-topic distribution matrix.
 
     Returns:
-        (list): Indices of documents sorted by dominant topics.
+        Sequence[int]: Indices of documents sorted by dominant topics.
     """
     n, k = L_matrix.shape
     L_normalized = L_matrix / L_matrix.sum(axis=1, keepdims=True)
 
-    def get_document_info() -> List[Tuple[int, int, float]]:
+    def get_document_info() -> Sequence[Tuple[int, int, float]]:
         dominant_topics = np.argmax(L_normalized, axis=1)
         dominant_props = L_normalized[np.arange(n), dominant_topics]
         return list(zip(range(n), dominant_topics, dominant_props))
 
-    def group_by_topic(doc_info: List[Tuple[int, int, float]]) -> defaultdict:
-        groups: defaultdict = defaultdict(list)
+    def group_by_topic(
+        doc_info: Sequence[Tuple[int, int, float]],
+    ) -> MutableMapping[int, list]:
+        groups: MutableMapping[int, list] = defaultdict(list)
         for idx, topic, prop in doc_info:
             groups[topic].append((idx, prop))
         return groups
 
-    def sort_topic_groups(grouped_docs: defaultdict) -> List[int]:
+    def sort_topic_groups(grouped_docs: MutableMapping[int, list]) -> Sequence[int]:
         sorted_indices = []
         for topic in range(k):
             docs_in_topic = grouped_docs.get(topic, [])


### PR DESCRIPTION
Fixes #10 
Fixes #13 

This PR refactors the type hints to:

- Use more base abstract classes so that they are not limiting to specific implementations.
- Use shorthand syntax to replace `Optional` and `Union` (requires Python >= 3.10).