### PR TITLE
Release tinytopics 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## tinytopics 0.5.0
+
+### Improvements
+
+- Increased the speed of `generate_synthetic_data()` significantly by using
+  direct mixture sampling, which leverages the properties of multinomial
+  distributions (#21).
+
+    This change makes simulating data at the scale of 100K x 100K
+    more feasible. Although the approaches before and after are mathematically
+    equivalent, the data generated with the same seed in previous versions and
+    this version onward will be bitwise different.
+
 ## tinytopics 0.4.1
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 ![License](https://img.shields.io/pypi/l/tinytopics)
 
 Topic modeling via sum-to-one constrained neural Poisson NMF.
-
 Built with PyTorch, runs on both CPUs and GPUs.
 
 ## Installation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## tinytopics 0.5.0
+
+### Improvements
+
+- Increased the speed of `generate_synthetic_data()` significantly by using
+  direct mixture sampling, which leverages the properties of multinomial
+  distributions (#21).
+
+    This change makes simulating data at the scale of 100K x 100K
+    more feasible. Although the approaches before and after are mathematically
+    equivalent, the data generated with the same seed in previous versions and
+    this version onward will be bitwise different.
+
 ## tinytopics 0.4.1
 
 ### Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,6 @@
 ![License](https://img.shields.io/pypi/l/tinytopics)
 
 Topic modeling via sum-to-one constrained neural Poisson NMF.
-
 Built with PyTorch, runs on both CPUs and GPUs.
 
 ## Installation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,4 +83,3 @@ theme:
   - search.highlight
   - search.suggest
   - toc.follow
-  - toc.integrate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinytopics"
-version = "0.4.1"
+version = "0.5.0"
 description = "Topic modeling via sum-to-one constrained neural Poisson non-negative matrix factorization"
 authors = [
     { name = "Nan Xiao", email = "me@nanx.me" }

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -200,7 +200,7 @@ mkdocs-autorefs==1.2.0
     # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-material==9.5.47
+mkdocs-material==9.5.48
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocstrings==0.27.0
@@ -227,7 +227,7 @@ notebook==7.3.1
 notebook-shim==0.2.4
     # via jupyterlab
     # via notebook
-numpy==2.1.3
+numpy==2.2.0
     # via contourpy
     # via imageio
     # via matplotlib

--- a/requirements.lock
+++ b/requirements.lock
@@ -37,7 +37,7 @@ mpmath==1.3.0
 networkx==3.4.2
     # via scikit-image
     # via torch
-numpy==2.1.3
+numpy==2.2.0
     # via contourpy
     # via imageio
     # via matplotlib


### PR DESCRIPTION
This PR bumps the version to 0.5.0 and updates the changelog.

Also runs `rye sync --update-all` and switches to the three-column layout for the mkdocs site.