### PR TITLE
Use tqdm.auto for better notebook progress bar visuals

### DIFF
--- a/docs/articles/memory.md
+++ b/docs/articles/memory.md
@@ -89,7 +89,7 @@ mode.
 
 ``` python
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import tinytopics as tt
 

--- a/docs/articles/memory.qmd
+++ b/docs/articles/memory.qmd
@@ -92,7 +92,7 @@ and save it into a 186GB `.npy` file using NumPy memory-mapped mode.
 
 ```{python}
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import tinytopics as tt
 

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -35,7 +35,7 @@ model, losses = tt.fit_model(dataset, k=k, num_epochs=100)
 tt.plot_loss(losses, output_file="loss.png")
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import tinytopics as tt
 

--- a/src/tinytopics/fit.py
+++ b/src/tinytopics/fit.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from torch.optim import AdamW
 from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
 from torch.utils.data import DataLoader, Dataset
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .models import NeuralPoissonNMF
 

--- a/src/tinytopics/utils.py
+++ b/src/tinytopics/utils.py
@@ -7,7 +7,7 @@ import torch
 import numpy as np
 from torch.utils.data import Dataset
 from scipy.optimize import linear_sum_assignment
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 def set_random_seed(seed: int) -> None:


### PR DESCRIPTION
This PR changes the vanilla `from tqdm import tqdm` to `from tqdm.auto import tqdm` so that Jupyter notebook users can get a better-looking progress bar. `tqdm.auto` resolves in this order:

- `tqdm.autonotebook`
- `tqdm.asyncio`
- `tqdm.std`