### PR TITLE
Use absolute URL logo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tinytopics <img src="docs/assets/logo.png" align="right" width="120" />
+# tinytopics <img src="https://github.com/nanxstats/tinytopics/raw/main/docs/assets/logo.png" align="right" width="120" />
 
 [![PyPI version](https://img.shields.io/pypi/v/tinytopics)](https://pypi.org/project/tinytopics/)
 ![Python versions](https://img.shields.io/pypi/pyversions/tinytopics)

--- a/docs/scripts/sync.sh
+++ b/docs/scripts/sync.sh
@@ -34,7 +34,7 @@ for article in get-started benchmark text memory distributed; do
 done
 
 # Sync README.md with modified image path for docs/index.md
-awk '{gsub("docs/assets/logo.png", "assets/logo.png"); print}' README.md > docs/index.md
+awk '{gsub("https://github.com/nanxstats/tinytopics/raw/main/docs/assets/logo.png", "assets/logo.png"); print}' README.md > docs/index.md
 
 # Sync CHANGELOG.md with docs/changelog.md
 cp CHANGELOG.md docs/changelog.md


### PR DESCRIPTION
This PR replaces the relative path logo with an absolute URL so that the image renders properly on PyPI.