### PR TITLE
Remove download statistics badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![Python versions](https://img.shields.io/pypi/pyversions/tinytopics)
 [![CI Tests](https://github.com/nanxstats/tinytopics/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/nanxstats/tinytopics/actions/workflows/ci-tests.yml)
 [![mkdocs](https://github.com/nanxstats/tinytopics/actions/workflows/mkdocs.yml/badge.svg)](https://nanx.me/tinytopics/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/tinytopics)](https://pypistats.org/packages/tinytopics)
 ![License](https://img.shields.io/pypi/l/tinytopics)
 
 Topic modeling via sum-to-one constrained neural Poisson NMF.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,6 @@
 ![Python versions](https://img.shields.io/pypi/pyversions/tinytopics)
 [![CI Tests](https://github.com/nanxstats/tinytopics/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/nanxstats/tinytopics/actions/workflows/ci-tests.yml)
 [![mkdocs](https://github.com/nanxstats/tinytopics/actions/workflows/mkdocs.yml/badge.svg)](https://nanx.me/tinytopics/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/tinytopics)](https://pypistats.org/packages/tinytopics)
 ![License](https://img.shields.io/pypi/l/tinytopics)
 
 Topic modeling via sum-to-one constrained neural Poisson NMF.


### PR DESCRIPTION
This PR removes the download statistics badge from `README.md` because:

- The third-party "pypistats" site is down for several days (HTTP 502 server error). The badge currently shows "downloads | inaccessible" which can be confusing.
- The official [Python packaging user guide](https://packaging.python.org/en/latest/guides/analyzing-pypi-package-downloads/) listed a few convincing reasons why PyPI does not display "download statistics" due to the lack of accuracy and usefulness.